### PR TITLE
Added navigation and updated syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,9 @@ Plug 'kblin/vim-fountain'
 
 to your `.vimrc` file.
 
+
+## Fountain-Screenplay-Processor
+
+I am adding all syntax for maximum compatibility with [Fountain Screenplay Processor](https://github.com/xiota/fountain-screenplay-processor).
+
+Please see [that project's documentation](https://github.com/xiota/fountain-screenplay-processor/blob/main/Fountain_Syntax.md) to learn about the extra tagging included here.

--- a/ftplugin/fountain.vim
+++ b/ftplugin/fountain.vim
@@ -1,27 +1,6 @@
-" =============================
-" Make line uppercase then <cr>
-" =============================
-
-nnoremap <s-cr> gUU<cr>
-
-" ==========================
-" Move between scene heading
-" ==========================
-
-function! s:NextSection(backwards)
-    let pattern = '\v^(INT|EXT)[.]\s'
-
-    if a:backwards
-        let dir = '?'
-    else
-        let dir = '/'
-    endif
-
-    execute 'silent normal! ' . dir . pattern . "\r"
-endfunction
-
-noremap <script> <buffer> <silent> ]]
-        \ :call <SID>NextSection(0)<cr>
-
-noremap <script> <buffer> <silent> [[
-        \ :call <SID>NextSection(1)<cr>
+"Jump Between Scenes & Notes
+map <silent> [[ <esc>?^INT.*\\|^EXT.*\\|^I\/E.*\\|^E\/I.*\\|[[.*\]\]<CR>
+map <silent> ]] <esc>/^INT.*\\|^EXT.*\\|^I\/E.*\\|^E\/I.*\\|[[.*\]\]<CR>
+"Jump Between Sections & Notes
+map <silent> ][ <esc>?^#.*\n\\|[[.*\]\]<CR>
+map <silent> [] <esc>/^#.*\n\\|[[.*\]\]<CR>

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -18,7 +18,7 @@ syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)"
 syn region fountainDialogue matchgroup=fountainCharacter start="\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
-syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)\|\(^\(\L\)* OUT:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
 syn match fountainUnderlined "_[^_]*_" 

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -19,6 +19,8 @@ syn region fountainDialogue matchgroup=fountainCharacter start="\(^\s*@\(.*\)\)\
 syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)\|\(^\(\L\)* OUT:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition1 "\(^\(\L\)* SHOT:$\)\|\(^\(\L\)* FRAME:$\)\|\(^\(\L\)* WITH:$\)\|\(^\(\L\)* SCREEN:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)\|\(^\DISSOLVE:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
 syn match fountainUnderlined "_[^_]*_" 
@@ -48,6 +50,8 @@ hi def link fountainCharacter			identifier
 hi def link fountainDialogue			statement
 hi def link fountainParenthetical		conditional
 hi def link fountainTransition			todo
+hi def link fountainTransition1			todo
+hi def link fountainTransition2			todo
 hi def link fountainLyric				normal
 hi def link fountainTransitionForced	todo
 hi def link fountainCentered			character

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -21,6 +21,7 @@ syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,foun
 syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)\|\(^\(\L\)* OUT:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransition1 "\(^\(\L\)* SHOT:$\)\|\(^\(\L\)* FRAME:$\)\|\(^\(\L\)* WITH:$\)\|\(^\(\L\)* SCREEN:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)" contains=fountainBoneyard,fountainNotes
+"Single Word Transitions - WIPE doesn't work?
 syn match fountainTransition3 "\(^\DISSOLVE:$\)\|\(^\WIPE:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
@@ -42,6 +43,7 @@ syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained
+
 
 hi def link fountainTitlePage		    PreProc
 hi def link fountainSection1 			Underlined

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -92,13 +92,6 @@ function! FountainFolds()
   endif
 endfunction
 
-"Jump Between Scenes & Notes
-map <silent> [[ <esc>?^INT.*\\|^EXT.*\\|^I\/E.*\\|^E\/I.*\\|[[.*\]\]<CR>
-map <silent> ]] <esc>/^INT.*\\|^EXT.*\\|^I\/E.*\\|^E\/I.*\\|[[.*\]\]<CR>
-"Jump Between Sections & Notes
-map <silent> ][ <esc>?^#.*\n\\|[[.*\]\]<CR>
-map <silent> [] <esc>/^#.*\n\\|[[.*\]\]<CR>
-
 setlocal foldmethod=expr
 setlocal foldexpr=FountainFolds()
 

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -18,7 +18,7 @@ syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)"
 syn region fountainDialogue matchgroup=fountainCharacter start="\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
-syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
 syn match fountainUnderlined "_[^_]*_" 

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -20,8 +20,8 @@ syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoney
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)\|\(^\(\L\)* OUT:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransition1 "\(^\(\L\)* SHOT:$\)\|\(^\(\L\)* FRAME:$\)\|\(^\(\L\)* WITH:$\)\|\(^\(\L\)* SCREEN:$\)" contains=fountainBoneyard,fountainNotes
-syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)\(^\DISSOLVE:$\)" contains=fountainBoneyard,fountainNotes
-"WIPE work around - an UPPERCASE single word with a colon
+syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)" contains=fountainBoneyard,fountainNotes
+"Any UPPERCASE single word with a colon by itself is a Transition
 syn match fountainTransition3 "\(^\(\L\)*:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -20,9 +20,9 @@ syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoney
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)\|\(^\(\L\)* OUT:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransition1 "\(^\(\L\)* SHOT:$\)\|\(^\(\L\)* FRAME:$\)\|\(^\(\L\)* WITH:$\)\|\(^\(\L\)* SCREEN:$\)" contains=fountainBoneyard,fountainNotes
-syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)" contains=fountainBoneyard,fountainNotes
-"Single Word Transitions - WIPE doesn't work?
-syn match fountainTransition3 "\(^\DISSOLVE:$\)\|\(^\WIPE:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)\(^\DISSOLVE:$\)" contains=fountainBoneyard,fountainNotes
+"WIPE work around - an UPPERCASE single word with a colon
+syn match fountainTransition3 "\(^\(\L\)*:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
 syn match fountainUnderlined "_[^_]*_" 

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -20,7 +20,8 @@ syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoney
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)\|\(^\(\L\)* CREDITS:$\)\|\(^\(\L\)* OUT:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransition1 "\(^\(\L\)* SHOT:$\)\|\(^\(\L\)* FRAME:$\)\|\(^\(\L\)* WITH:$\)\|\(^\(\L\)* SCREEN:$\)" contains=fountainBoneyard,fountainNotes
-syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)\|\(^\DISSOLVE:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition2 "\(^\(\L\)* CUT:$\)\|\(^\(\L\)* OVER:$\)" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition3 "\(^\DISSOLVE:$\)\|\(^\WIPE:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
 syn match fountainUnderlined "_[^_]*_" 
@@ -36,8 +37,8 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
-syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
+syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EST\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EST\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained
@@ -52,6 +53,7 @@ hi def link fountainParenthetical		conditional
 hi def link fountainTransition			todo
 hi def link fountainTransition1			todo
 hi def link fountainTransition2			todo
+hi def link fountainTransition3			todo
 hi def link fountainLyric				normal
 hi def link fountainTransitionForced	todo
 hi def link fountainCentered			character

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -18,7 +18,7 @@ syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)"
 syn region fountainDialogue matchgroup=fountainCharacter start="\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
-syn match fountainTransition "^\(\L\)* TO:$" contains=fountainBoneyard,fountainNotes
+syn match fountainTransition "\(^\(\L\)* TO:$\)\|\(^\(\L\)* IN:$\)" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
 syn match fountainUnderlined "_[^_]*_" 

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -38,8 +38,8 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EST\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
-syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EST\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
+syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EST\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EST \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EST\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EST \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained

--- a/syntax/fountain.vim
+++ b/syntax/fountain.vim
@@ -11,11 +11,13 @@ if exists("b:current_syntax")
 endif
 syn sync minlines=200
 
+syn match fountainAction "^\(\a\)*\s*.*$" contains=fountainBoneyard,fountainNotes
 syn match fountainSection1 "^\s*# \(\_[^#]\)" fold transparent contains=ALL
 syn region fountainTitlePage start="\%^\(.*\):" end="^$" contains=fountainBoneyard,fountainNotes
-syn match fountainCharacter "^\(\L\)*$" 
-syn region fountainDialogue matchgroup=fountainCharacter start="^\(\L\)*$" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainEmphasis
+syn match fountainCharacter "\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" 
+syn region fountainDialogue matchgroup=fountainCharacter start="\(^\s*@\(.*\)\)\|\(^\(\L\)*$\)" end="^\s*$" contains=fountainCharacter,fountainParenthetical,fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn match fountainParenthetical "^\s*\((.*)\)$" contained contains=fountainBoneyard,fountainNotes
+syn match fountainLyric "^\s*\~\(.*\)$" contained contains=fountainBoneyard,fountainNotes
 syn match fountainTransition "^\(\L\)* TO:$" contains=fountainBoneyard,fountainNotes
 syn match fountainTransitionForced "^\s*>\(.*\)" contains=fountainBoneyard,fountainNotes
 syn match fountainCentered "^\s*>\(.*\)<" contains=fountainBoneyard,fountainNotes
@@ -32,34 +34,77 @@ syn region fountainHeader4 start="^\s*#### " end="$" contains=fountainBoneyard,f
 syn region fountainHeader5 start="^\s*##### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainHeader6 start="^\s*###### " end="$" contains=fountainBoneyard,fountainNotes
 syn region fountainSynopses start="^\s*= " end="$" contains=fountainBoneyard,fountainNotes
-syn region fountainSceneHeading start="^\s*\(\.\|INT\. \|EXT\. \|INT\./EXT\. \|INT/EXT\. \|INT \|EXT \|INT/EXT \|I/E \|int\. \|ext\. \|int\./ext\. \|int/ext\. \|int \|ext \|int/ext \|i/e \)" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\c" end="$" contains=fountainSceneNumber,fountainBoneyard,fountainNotes 
+syn region fountainAction matchgroup=fountainSceneHeading start="^\s*\(\.[^\. ]\|INT\. \|EXT\. \|INT\.\/EXT\. \|INT\/EXT\. \|INT \|EXT \|INT\/EXT \|I\/E \)\(.*\)$\n*\ze\a\c" end="\n\n" contains=fountainBoneyard,fountainNotes,fountainBold,fountainUnderlined,fountainItalic,fountainBoldItalic
 syn region fountainBoneyard start="/\*" end="\*\/" contains=xLineContinue
 syn match xLineContinue "\\$" contained
 syn region fountainSceneNumber start="#" end="#" contained
 
-hi def link fountainTitlePage		    title
+hi def link fountainTitlePage		    PreProc
+hi def link fountainSection1 			Underlined
 hi def link fountainSceneHeading	    title
+hi def link fountainAction              string
 hi def link fountainCharacter			identifier 
 hi def link fountainDialogue			statement
-hi def link fountainParenthetical		function
+hi def link fountainParenthetical		conditional
 hi def link fountainTransition			todo
+hi def link fountainLyric				normal
 hi def link fountainTransitionForced	todo
 hi def link fountainCentered			character
-hi fountainUnderlined					gui=underline
-hi fountainItalic						gui=italic cterm=italic	
-hi fountainBold							gui=bold cterm=bold	
-hi fountainBoldItalic					gui=bold,italic cterm=bold,italic	
+hi def fountainUnderlined					gui=underline
+hi def fountainItalic						gui=italic cterm=italic	
+hi def fountainBold							gui=bold cterm=bold
+hi def fountainBoldItalic					gui=bold,italic cterm=bold,italic	
 hi def link fountainPagebreak			conditional
 hi def link fountainActionForced		normal
 hi def link fountainNotes				comment
 hi def link fountainBoneyard			nontext	
-hi def link fountainHeader1				htmlH1	
-hi def link fountainHeader2				htmlH2	
-hi def link fountainHeader3				htmlH3	
-hi def link fountainHeader4				htmlH4	
-hi def link fountainHeader5				htmlH5	
-hi def link fountainHeader6				htmlH6	
+hi def link fountainHeader1				CursorLineNr	
+hi def link fountainHeader2				CursorLineNr	
+hi def link fountainHeader3				CursorLineNr	
+hi def link fountainHeader4				CursorLineNr	
+hi def link fountainHeader5				CursorLineNr	
+hi def link fountainHeader6				CursorLineNr	
 hi def link fountainSynopses			number
 hi def link fountainSceneNumber			number	
 
+function! FountainFolds()
+  let thisline = getline(v:lnum)
+  let laterline = getline(v:lnum + 2)
+  if match(thisline, '^EXT') >= 0
+    return ">1"
+  elseif match(thisline, '^INT') >= 0
+    return ">1"
+  elseif match(thisline, '^Title:') >= 0
+    return ">1"
+  elseif match(thisline, '^\.[^.]') >= 0
+    return ">1"
+  elseif match(laterline, '^EXT') >= 0
+    return "<1"
+  elseif match(laterline, '^INT') >= 0
+    return "<1"
+  elseif match(laterline, '^Title:') >= 0
+    return "<1"
+  elseif match(laterline, '^\.[^.]') >= 0
+    return "<1"
+  else
+    return "="
+  endif
+endfunction
+
+"Jump Between Scenes & Notes
+map <silent> [[ <esc>?^INT.*\\|^EXT.*\\|^I\/E.*\\|^E\/I.*\\|[[.*\]\]<CR>
+map <silent> ]] <esc>/^INT.*\\|^EXT.*\\|^I\/E.*\\|^E\/I.*\\|[[.*\]\]<CR>
+"Jump Between Sections & Notes
+map <silent> ][ <esc>?^#.*\n\\|[[.*\]\]<CR>
+map <silent> [] <esc>/^#.*\n\\|[[.*\]\]<CR>
+
+setlocal foldmethod=expr
+setlocal foldexpr=FountainFolds()
+
+function! FountainFoldText()
+  let foldsize = (v:foldend-v:foldstart)
+  return getline(v:foldstart).' ('.foldsize.' lines)'
+endfunction
+setlocal foldtext=FountainFoldText()
 let b:current_syntax = "fountain"


### PR DESCRIPTION
Added [[ and ]] navigation between headings and [[ notes ]]. I included those notes because I most often use them in places that I need to revisit. So, making the heading navigation stop on those notes as well was a good reminder that things still needed to be checked.

And, [fountain-screenplay-processor](https://github.com/xiota/fountain-screenplay-processor/blob/main/Fountain_Syntax.md) recognizes EST (Establishing Shot) as a `SceneHeading` as well as a larger number of `StockTransitions`. I added support for the ones listed in their documentation.

I did have an issue with `WIPE:` being recognized as a `CharacterName` instead of a `Transition`. So, in thinking about it, I added code that recognizes **any** single UPPERCASE word and a colon but no spaces as a `Transition`.

Odds are, my additions could be streamlined a bit.